### PR TITLE
Release the "parameters" buffer after the corresponding callback is i…

### DIFF
--- a/src/rvi.c
+++ b/src/rvi.c
@@ -1850,5 +1850,6 @@ int rviReadRcv( TRviHandle handle, json_t *msg, TRviRemote *remote )
 
 exit:
     if( skey.name ) free( skey.name );
+    if( parameters ) free( parameters );
     return err;
 }


### PR DESCRIPTION
…nvoked in rviReadRcv.

Otherwise, memory leak occurs.