### PR TITLE
Fix a crash issue if the system time is not within the credential val…

### DIFF
--- a/src/rvi.c
+++ b/src/rvi.c
@@ -855,6 +855,7 @@ int rviValidateCredential( TRviHandle handle, const char *cred, X509 *cert )
     X509            *dcert = {0};
     const char      certHead[] = "-----BEGIN CERTIFICATE-----\n";
     const char      certFoot[] = "\n-----END CERTIFICATE-----";
+    char            *tmp = NULL;
 
     ret = RVI_OK;
 
@@ -884,7 +885,7 @@ int rviValidateCredential( TRviHandle handle, const char *cred, X509 *cert )
     if( ( start > rawtime ) || ( stop < rawtime ) ) { ret = -1; goto exit; }
 
     const char *deviceCert = jwt_get_grant( jwt, "device_cert" );
-    char *tmp = malloc( strlen( deviceCert ) + strlen( certHead ) 
+    tmp = malloc( strlen( deviceCert ) + strlen( certHead ) 
                         + strlen ( certFoot ) + 1 );
     if( !tmp ) { ret = ENOMEM; goto exit; }
     sprintf(tmp, "%s%s%s", certHead, deviceCert, certFoot);


### PR DESCRIPTION
…idity time span.

The "tmp" buffer was defined after the time validity check.