### PR TITLE
Fixes services callbacks on 32 bit systems 

### DIFF
--- a/src/rvi.c
+++ b/src/rvi.c
@@ -1820,7 +1820,7 @@ int rviReadRcv( TRviHandle handle, json_t *msg, TRviRemote *remote )
     tmp = json_object_get( msg, "data" );
     if( !tmp ) { err = RVI_ERR_JSON; goto exit; }
 
-    long timeout = json_integer_value( json_object_get( tmp, "timeout" ) );
+    long long timeout = json_integer_value( json_object_get( tmp, "timeout" ) );
     time(&rawtime);
     if( rawtime > timeout ) { err = RVI_ERR_JSON; goto exit; }
 


### PR DESCRIPTION
On the 32bit systems, type long is always 32bit it is not enough in our case, so registered services has never called.
Fixses  #19 