### PR TITLE
fixes crash when invoking service on 32 bit systems

### DIFF
--- a/src/rvi.c
+++ b/src/rvi.c
@@ -1440,7 +1440,7 @@ int rviInvokeService(TRviHandle handle, const char *serviceName,
     if ( !params ) { ret = RVI_ERR_JSON; goto exit; }
 
     rcv = json_pack( 
-            "{s:s, s:i, s:s, s:{s:s, s:i, s:o}}",
+            "{s:s, s:i, s:s, s:{s:s, s:I, s:o}}",
             "cmd", "rcv",
             "tid", 1, /* TODO: talk to Ulf about tid */
             "mod", "proto_json_rpc",


### PR DESCRIPTION
Crash happens when passing long long(64 bit)  to json_pack with parameter type "i" that uses int type and is 32 bit on 32 bit systems. 
Fixses #28 