### PR TITLE
rvi_list.h: Fix rviListGetCount

### DIFF
--- a/src/rvi_list.h
+++ b/src/rvi_list.h
@@ -36,7 +36,7 @@ int rviListRemove ( TRviList* list, void* record );
 
 int rviListRemoveHead ( TRviList* list, void** record );
 
-inline unsigned int rviListGetCount ( TRviList* list )
+static inline unsigned int rviListGetCount ( TRviList* list )
 {
     return list->count;
 }


### PR DESCRIPTION
Make rviListGetCount a static inline function to avoid issues with
multiple definitions while building Aktualizr (SOTA Client written
in C++) using a Yocto/OE recipe from layer meta-genivi-dev.

[GDP-575] Declare rviListGetCount as static inline function in rvi_lib

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>