### PR TITLE
New API init function that accepts config content instead of filename

### DIFF
--- a/include/rvi.h
+++ b/include/rvi.h
@@ -120,6 +120,18 @@ typedef enum {
 
 extern TRviHandle rviInit(char *configFilename);
 
+/** @brief Initialize the RVI library. Call before using any other functions.
+ *
+ * This function do the same as rviInit, but accepts config content, instead of file path.
+ *
+ * @param jsonConfig - config content.
+ *
+ * @return  A handle for the API on success, 
+ *          NULL otherwise.
+ */
+
+extern TRviHandle rviJsonInit(char *jsonConfig);
+
 /** @brief Tear down the API.
  *
  * Calling applications are expected to call this to cleanly tear down the API.


### PR DESCRIPTION
@cajun-rat @tjamison 
In aktualizr we use those changes to avoid to include separate config file for librvi, so maybe those changes could be useful for someone another. It is also better for us to use upstream version of library without patch it.
 