### PR TITLE
Include stdbool.h, for bool

### DIFF
--- a/include/rvi.h
+++ b/include/rvi.h
@@ -8,6 +8,7 @@
 #ifndef _RVI_H
 #define _RVI_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
The interactive.c example application compiles in C99 rather than C++, and thus
doesn't have the 'bool' type natively defined.  Include stdbool.h (which is in
C99) to make the 'bool' type available.