### PR TITLE
Remove 'const' from void* serviceData

### DIFF
--- a/src/rvi.c
+++ b/src/rvi.c
@@ -108,7 +108,7 @@ typedef struct TRviRights {
 
 TRviService *rviServiceCreate ( const char *name, const int registrant, 
                                     const TRviCallback callback, 
-                                    const void *serviceData );
+                                    void *serviceData );
 
 void rviServiceDestroy ( TRviService *service );
 
@@ -260,7 +260,7 @@ int rviComparePattern ( const char *pattern, const char *fqsn )
 
 TRviService *rviServiceCreate ( const char *name, const int registrant, 
                                     const TRviCallback callback, 
-                                    const void *serviceData )
+                                    void *serviceData )
 {
     /* If name is NULL or registrant is negative, there's an error */
     if ( !name || (registrant < 0) ) { return NULL; }


### PR DESCRIPTION
serviceData is used as an opaque 'user data' handle to be passed back to the
TRviCallback that the user registers in rviRegisterService. rviRegisterService
takes a 'void*', but the internal 'rviServiceCreate' is defined to take a
'const void*'. I believe the right interface here is non-const, since
TRviCallback is free to change the data blob it gets via the 'void *
serviceData' parameter.